### PR TITLE
Define unicode() in Python 3

### DIFF
--- a/freecad/plot/plotAxes/TaskPanel.py
+++ b/freecad/plot/plotAxes/TaskPanel.py
@@ -31,6 +31,11 @@ from freecad import plot
 from freecad.plot import Plot
 from freecad.plot.plotUtils import Paths
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 class TaskPanel:
     def __init__(self):

--- a/freecad/plot/plotLabels/TaskPanel.py
+++ b/freecad/plot/plotLabels/TaskPanel.py
@@ -30,6 +30,11 @@ from PySide import QtGui, QtCore
 from freecad.plot import Plot
 from freecad.plot.plotUtils import Paths
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 class TaskPanel:
     def __init__(self):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/FreeCAD/freecad.plot on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./setup.py:29:19: F821 undefined name '__version__'
      version=str(__version__),
                  ^
./freecad/plot/init_gui.py:62:13: F821 undefined name 'FreeCAD'
            FreeCAD.Console.PrintMessage(msg + '\n')
            ^
./freecad/plot/plotLabels/TaskPanel.py:225:20: F821 undefined name 'unicode'
        Plot.title(unicode(form.title.text()))
                   ^
./freecad/plot/plotLabels/TaskPanel.py:226:21: F821 undefined name 'unicode'
        Plot.xlabel(unicode(form.xLabel.text()))
                    ^
./freecad/plot/plotLabels/TaskPanel.py:227:21: F821 undefined name 'unicode'
        Plot.ylabel(unicode(form.yLabel.text()))
                    ^
./freecad/plot/plotAxes/TaskPanel.py:459:25: F821 undefined name 'unicode'
            Plot.xlabel(unicode(x))
                        ^
./freecad/plot/plotAxes/TaskPanel.py:460:25: F821 undefined name 'unicode'
            Plot.ylabel(unicode(y))
                        ^
7     F821 undefined name 'FreeCAD'
7
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree