### PR TITLE
Allow installation by AddOn manager - compile resources if absent

### DIFF
--- a/freecad/plot/PlotGui.py
+++ b/freecad/plot/PlotGui.py
@@ -27,7 +27,32 @@ import FreeCAD
 import FreeCADGui
 import os
 
-from . import Plot_rc
+def CompileResources():
+    import subprocess as sub
+    # try to create a resource file
+    # assume either pyside2-rcc or pyside-rcc are available.
+    # if both are available pyside2-rcc is used.
+    rc_input = os.path.abspath(os.path.join(os.path.dirname(__file__), "resources", "Plot.qrc"))
+    rc_output = os.path.join(os.path.dirname(__file__), "Plot_rc.py")
+    try:
+        try:
+            proc = sub.Popen(["pyside2-rcc", "-o", rc_output, rc_input], stdout=sub.PIPE, stderr=sub.PIPE, universal_newlines=True)
+            out, err = proc.communicate()
+        except FileNotFoundError:
+            proc = sub.Popen(["pyside-rcc", "-o", rc_output, rc_input], stdout=sub.PIPE, stderr=sub.PIPE, universal_newlines=True)
+            out, err = proc.communicate()
+        print(out)
+        print(err)
+    except Exception as e:
+        print("An error occured while trying to create the resource file: \n" + str(e))
+
+
+try:
+    from . import Plot_rc
+except ImportError:
+    print("Plot: Trying to compile resources")    
+    CompileResources()
+    from . import Plot_rc
 
 
 FreeCADGui.addLanguagePath(":/Plot/translations")

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,13 @@
 from setuptools import setup
 import os
-import subprocess as sub
+from freecad.plot.PlotGui import CompileResources
 
 version_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 
                             "freecad", "plot", "version.py")
 with open(version_path) as fp:
     exec(fp.read())
     
-# try to create a resource file
-# assume either pyside2-rcc or pyside-rcc are available.
-# if both are available pyside2-rcc is used.
-rc_input = os.path.abspath(os.path.join("freecad", "plot", "resources", "Plot.qrc"))
-rc_output = os.path.join("freecad", "plot", "Plot_rc.py")
-try:
-    try:
-        proc = sub.Popen(["pyside2-rcc", "-o", rc_output, rc_input], stdout=sub.PIPE, stderr=sub.PIPE)
-        out, err = proc.communicate()
-    except FileNotFoundError:
-        proc = sub.Popen(["pyside-rcc", "-o", rc_output, rc_input], stdout=sub.PIPE, stderr=sub.PIPE)
-        out, err = proc.communicate()
-except Exception as e:
-    print("An error occured while trying to create the resource file: \n" + str(e))
-
-print(out.decode("utf8"))
-print(err.decode("utf8"))
+CompileResources()
 
 setup(name='freecad.plot',
       version=str(__version__),


### PR DESCRIPTION
As far as I know, the AddOn manager doesn't have an install hook that could be used to compile resources as in the setup.py file. Therefore this pull request compiles the resources if they are not found (i.e. on first use after is has been installed).
