### PR TITLE
Prevent matplotlib selecting the PyQt API instead of PySide2

### DIFF
--- a/freecad/plot/init_gui.py
+++ b/freecad/plot/init_gui.py
@@ -26,7 +26,17 @@ import FreeCADGui as Gui
 import os, sys
 
 import matplotlib
+
+# Force matplotlib to use PySide backend by temporarily unloading PyQt
+PyQt5WasLoaded = False
+if 'PyQt5.QtCore' in sys.modules:
+    del sys.modules['PyQt5.QtCore']
+    PyQt5WasLoaded = True
+
 import matplotlib.pyplot as plt
+
+if PyQt5WasLoaded:
+    import PyQt5.QtCore
 
 matplotlib.use("module://freecad.plot.freecad_backend")
 matplotlib.style.use('seaborn-colorblind')


### PR DESCRIPTION
Running the FreeCAD daily build under Ubuntu 20.04, I have had the following error when the CfdOF workbench tries to create a plot:

```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/oliver/.FreeCAD/Mod/Plot/freecad/plot/Plot.py", line 110, in figure
    win = Plot(winTitle)
  File "/home/oliver/.FreeCAD/Mod/Plot/freecad/plot/Plot.py", line 423, in __init__
    self.canvas.setParent(self)
TypeError: arguments did not match any overloaded call:
  setParent(self, QWidget): argument 1 has unexpected type 'Plot'
  setParent(self, QWidget, Union[Qt.WindowFlags, Qt.WindowType]): argument 1 has unexpected type 'Plot'
```

This can be reproduced by entering the following in the python console.
```
from freecad.plot import Plot
Plot.figure("foo")
```

Further investigation revealed that on my system, when the modules are loaded, sys.modules contains 'PyQt.QtCore', causing matplotlib to select the PyQt5 API rather than PySide2 as it should. I don't know the reasons for this, but the attached commit forces matplotlib to select PySide2 by temporarily unloading the PyQt5.QtCore module if it is found.
