### PR TITLE
[Plot] Handle subtle changes in matplotlib style sheet names

### DIFF
--- a/freecad/plot/init_gui.py
+++ b/freecad/plot/init_gui.py
@@ -39,7 +39,21 @@ if PyQt5WasLoaded:
     import PyQt5.QtCore
 
 matplotlib.use("module://freecad.plot.freecad_backend")
-matplotlib.style.use('seaborn-colorblind')
+style_list = ['default', 'classic'] + sorted(
+    style for style in plt.style.available
+    if style != 'classic' and not style.startswith('_') and 'colorblind' in style)
+sorted_style_list = sorted(style_list, reverse = True)
+if len(sorted_style_list) > 1:
+    matplotlib.style.use(sorted_style_list[1])
+elif len(sorted_style_list) == 1:
+    matplotlib.style.use(sorted_style_list[0])
+else:
+    from PySide import QtCore, QtGui
+    msg = QtGui.QApplication.translate(
+        "plot_console",
+        "matplotlib style sheets not found",
+        None)
+    FreeCAD.Console.PrintWarning(msg + '\n')
 matplotlib.rcParams["figure.facecolor"] = "efefef"
 matplotlib.rcParams["axes.facecolor"] = "efefef"
 


### PR DESCRIPTION
See discussion https://forum.freecad.org/viewtopic.php?p=723751#p723751

Tested using:

```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.22.0dev.35274 (Git) AppImage
Build type: Release
Branch: main
Hash: dc063eabec61bffc72c92595c66a4649f25fe381
Python 3.10.13, Qt 5.15.8, Coin 4.0.0, Vtk 9.2.6, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Silk 0.1.3
  * Defeaturing 1.2.0
  * CurvedShapes 1.0.4
  * freecad.gears 1.1.0
  * Curves 0.6.13
  * Help 1.0.3
  * Plot 2022.4.17
  * CfdOF 1.24.8
  * fasteners 0.4.56
  * sheetmetal 0.3.0
```


```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.22.0dev.35308 (Git)
Build type: Release
Branch: main
Hash: 3eed1107c8fd5cf2f7668f3697df6b44d07d8c53
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Silk 0.1.3
  * Defeaturing 1.2.0
  * CurvedShapes 1.0.4
  * freecad.gears 1.1.0
  * Curves 0.6.13
  * Help 1.0.3
  * Plot 2022.4.17
  * CfdOF 1.24.8
  * fasteners 0.4.56
  * sheetmetal 0.3.0
```


```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.21.2.33772 (Git)
Build type: Release
Branch: releases/FreeCAD-0-21
Hash: abf147e2112c1ded4918435d2540f02be8a1ffc0
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Silk 0.1.3
  * Defeaturing 1.2.0
  * CurvedShapes 1.0.4
  * freecad.gears 1.1.0
  * Curves 0.6.13
  * Help 1.0.3
  * Plot 2022.4.17
  * CfdOF 1.24.8
  * fasteners 0.4.56
  * sheetmetal 0.3.0
```

